### PR TITLE
Refactor data-fp API URL to js env file

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -14,6 +14,7 @@
   <script src="{{ "/js/bootstrap.min.js" | prepend: site.baseurl }}"></script>
 
   <script src="{{ "/js/typeahead.js" | prepend: site.baseurl }}"></script>
+  <script src="{{ "/js/env-file.js" | prepend: site.baseurl }}"></script>
   <script src="{{ "/js/data-fp.js" | prepend: site.baseurl }}"></script>
 
   <!-- BC Gov style/scripts -->

--- a/js/data-fp.js
+++ b/js/data-fp.js
@@ -1,6 +1,6 @@
 (function($) {
 	$(document).ready(function() {
-		var feedsUrl = 'https://dbcfeeds.api.gov.bc.ca/';
+		var feedsUrl = window.DATA_FP_API;
 
 		var feed_data = {
 			dataset_count: 0,

--- a/js/env-file.js
+++ b/js/env-file.js
@@ -1,0 +1,2 @@
+// File for dynamically loading env vars at runtime
+DATA_FP_API="<URL_TO_API>";


### PR DESCRIPTION
Goal: To allow the API URL to be set at build or deploy time, allowing it to be changed between environments, allowing the proper deployment of the API in Dev and Test.

Changes made:
- add environment js file to index header
- update feedsURL to pull variable from environment file
- add sample env file to be overwritten at deploy time

Solution: Refactor to use a separate "environment" file. This file can be injected at build or deploy time to allow different URLs to be used in each environment.